### PR TITLE
Show progress in Windows taskbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,5 @@ build/_out/*
 !build/keys
 !build/tools/*
 !build/tools/scriptcs/*
+
+.vs

--- a/src/ShellProgressBar.Example/TestCases/DeeplyNestedProgressBarTreeExample.cs
+++ b/src/ShellProgressBar.Example/TestCases/DeeplyNestedProgressBarTreeExample.cs
@@ -15,6 +15,7 @@ namespace ShellProgressBar.Example.TestCases
 			var overProgressOptions = new ProgressBarOptions
 			{
 				BackgroundColor = ConsoleColor.DarkGray,
+				EnableTaskBarProgress = true,
 			};
 
 			using (var pbar = new ProgressBar(numberOfSteps, "overall progress", overProgressOptions))

--- a/src/ShellProgressBar/ProgressBar.cs
+++ b/src/ShellProgressBar/ProgressBar.cs
@@ -35,6 +35,9 @@ namespace ShellProgressBar
 
 			Console.CursorVisible = false;
 
+			if (this.Options.EnableTaskBarProgress)
+				TaskbarProgress.SetState(TaskbarProgress.TaskbarStates.Normal);
+
 			if (this.Options.DisplayTimeInRealTime)
 				_timer = new Timer((s) => DisplayProgress(), null, 500, 500);
 			else //draw once
@@ -196,6 +199,9 @@ namespace ShellProgressBar
 					ProgressBarBottomHalf(mainPercentage, this._startDate, null, this.Message, indentation, this.Options.ProgressBarOnBottom);
 				}
 
+				if (this.Options.EnableTaskBarProgress)
+					TaskbarProgress.SetValue(mainPercentage, 100);
+
 				DrawChildren(this.Children, indentation);
 
 				ResetToBottom();
@@ -284,6 +290,9 @@ namespace ShellProgressBar
 		{
 			if (this.EndTime == null) this.EndTime = DateTime.Now;
 			var openDescendantsPadding = (_visisbleDescendants * 2);
+
+			if (this.Options.EnableTaskBarProgress)
+				TaskbarProgress.SetState(TaskbarProgress.TaskbarStates.NoProgress);
 
 			try
 			{

--- a/src/ShellProgressBar/ProgressBarOptions.cs
+++ b/src/ShellProgressBar/ProgressBarOptions.cs
@@ -44,5 +44,13 @@ namespace ShellProgressBar
 		/// This setting swaps their position
 		/// </summary>
 		public bool ProgressBarOnBottom { get; set; }
+
+		/// <summary>
+		/// Use Windows' task bar to display progress.
+		/// </summary>
+		/// <remarks>
+		/// This feature is available on the Windows platform.
+		/// </remarks>
+		public bool EnableTaskBarProgress { get; set; }
 	}
 }

--- a/src/ShellProgressBar/TaskbarProgress.cs
+++ b/src/ShellProgressBar/TaskbarProgress.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace ShellProgressBar
+{
+	public static class TaskbarProgress
+	{
+		public enum TaskbarStates
+		{
+			NoProgress = 0,
+			Indeterminate = 0x1,
+			Normal = 0x2,
+			Error = 0x4,
+			Paused = 0x8
+		}
+
+		[ComImport()]
+		[Guid("ea1afb91-9e28-4b86-90e9-9e9f8a5eefaf")]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		private interface ITaskbarList3
+		{
+			// ITaskbarList
+			[PreserveSig]
+			void HrInit();
+
+			[PreserveSig]
+			void AddTab(IntPtr hwnd);
+
+			[PreserveSig]
+			void DeleteTab(IntPtr hwnd);
+
+			[PreserveSig]
+			void ActivateTab(IntPtr hwnd);
+
+			[PreserveSig]
+			void SetActiveAlt(IntPtr hwnd);
+
+			// ITaskbarList2
+			[PreserveSig]
+			void MarkFullscreenWindow(IntPtr hwnd, [MarshalAs(UnmanagedType.Bool)] bool fFullscreen);
+
+			// ITaskbarList3
+			[PreserveSig]
+			void SetProgressValue(IntPtr hwnd, UInt64 ullCompleted, UInt64 ullTotal);
+
+			[PreserveSig]
+			void SetProgressState(IntPtr hwnd, TaskbarStates state);
+		}
+
+		[ComImport]
+		[Guid("56fdf344-fd6d-11d0-958a-006097c9a090")]
+		[ClassInterface(ClassInterfaceType.None)]
+		private class TaskbarInstance
+		{}
+
+		[DllImport("kernel32.dll")]
+		static extern IntPtr GetConsoleWindow();
+
+		private static readonly ITaskbarList3 _taskbarInstance = (ITaskbarList3) new TaskbarInstance();
+		private static readonly bool _taskbarSupported = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+		public static void SetState(TaskbarStates taskbarState)
+		{
+			if (_taskbarSupported)
+				_taskbarInstance.SetProgressState(GetConsoleWindow(), taskbarState);
+		}
+
+		public static void SetValue(double progressValue, double progressMax)
+		{
+			if (_taskbarSupported)
+				_taskbarInstance.SetProgressValue(GetConsoleWindow(), (ulong) progressValue, (ulong) progressMax);
+		}
+	}
+}


### PR DESCRIPTION
This PR allows to show the progress of the main `ProgressBar` in the Windows taskbar.

It's off by default, you have to set `ProgressBarOptions.EnableTaskBarProgress` to `true` to enable it. Additionally it's available only on the Windows platform.

This fixes #1 .