### PR TITLE
Fix TypeLoadException on non-Windows platforms

### DIFF
--- a/src/ShellProgressBar.Example/TestCases/DeeplyNestedProgressBarTreeExample.cs
+++ b/src/ShellProgressBar.Example/TestCases/DeeplyNestedProgressBarTreeExample.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,7 +16,7 @@ namespace ShellProgressBar.Example.TestCases
 			var overProgressOptions = new ProgressBarOptions
 			{
 				BackgroundColor = ConsoleColor.DarkGray,
-				EnableTaskBarProgress = true,
+				EnableTaskBarProgress = RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
 			};
 
 			using (var pbar = new ProgressBar(numberOfSteps, "overall progress", overProgressOptions))

--- a/src/ShellProgressBar/ProgressBarOptions.cs
+++ b/src/ShellProgressBar/ProgressBarOptions.cs
@@ -1,56 +1,66 @@
 using System;
+using System.Runtime.InteropServices;
 
 namespace ShellProgressBar
 {
-	/// <summary>
-	/// Control the behaviour of your progressbar
-	/// </summary>
-	public class ProgressBarOptions
-	{
-		public static readonly ProgressBarOptions Default = new ProgressBarOptions();
+    /// <summary>
+    /// Control the behaviour of your progressbar
+    /// </summary>
+    public class ProgressBarOptions
+    {
+        private bool _enableTaskBarProgress;
+        public static readonly ProgressBarOptions Default = new ProgressBarOptions();
 
-		/// <summary> The foreground color of the progress bar, message and time</summary>
-		public ConsoleColor ForegroundColor { get; set; } = ConsoleColor.Green;
+        /// <summary> The foreground color of the progress bar, message and time</summary>
+        public ConsoleColor ForegroundColor { get; set; } = ConsoleColor.Green;
 
-		/// <summary> The foreground color the progressbar has reached a 100 percent</summary>
-		public ConsoleColor? ForegroundColorDone { get; set; }
+        /// <summary> The foreground color the progressbar has reached a 100 percent</summary>
+        public ConsoleColor? ForegroundColorDone { get; set; }
 
-		/// <summary> The background color of the remainder of the progressbar</summary>
-		public ConsoleColor? BackgroundColor { get; set; }
+        /// <summary> The background color of the remainder of the progressbar</summary>
+        public ConsoleColor? BackgroundColor { get; set; }
 
-		/// <summary> The character to use to draw the progressbar</summary>
-		public char ProgressCharacter { get; set; } = '\u2588';
+        /// <summary> The character to use to draw the progressbar</summary>
+        public char ProgressCharacter { get; set; } = '\u2588';
 
-		/// <summary>
-		/// The character to use for the background of the progress defaults to <see cref="ProgressCharacter"/>
-		/// </summary>
-		public char? BackgroundCharacter { get; set; }
+        /// <summary>
+        /// The character to use for the background of the progress defaults to <see cref="ProgressCharacter"/>
+        /// </summary>
+        public char? BackgroundCharacter { get; set; }
 
-		/// <summary>
-		/// When true will redraw the progressbar using a timer, otherwise only update when
-		/// <see cref="ProgressBarBase.Tick"/> is called.
-		/// Defaults to true
-		///  </summary>
-		public bool DisplayTimeInRealTime { get; set; } = true;
+        /// <summary>
+        /// When true will redraw the progressbar using a timer, otherwise only update when
+        /// <see cref="ProgressBarBase.Tick"/> is called.
+        /// Defaults to true
+        ///  </summary>
+        public bool DisplayTimeInRealTime { get; set; } = true;
 
-		/// <summary>
-		/// Collapse the progressbar when done, very useful for child progressbars
-		/// Defaults to true
-		/// </summary>
-		public bool CollapseWhenFinished { get; set; } = true;
+        /// <summary>
+        /// Collapse the progressbar when done, very useful for child progressbars
+        /// Defaults to true
+        /// </summary>
+        public bool CollapseWhenFinished { get; set; } = true;
 
-		/// <summary>
-		/// By default the text and time information is displayed at the bottom and the progress bar at the top.
-		/// This setting swaps their position
-		/// </summary>
-		public bool ProgressBarOnBottom { get; set; }
+        /// <summary>
+        /// By default the text and time information is displayed at the bottom and the progress bar at the top.
+        /// This setting swaps their position
+        /// </summary>
+        public bool ProgressBarOnBottom { get; set; }
 
-		/// <summary>
-		/// Use Windows' task bar to display progress.
-		/// </summary>
-		/// <remarks>
-		/// This feature is available on the Windows platform.
-		/// </remarks>
-		public bool EnableTaskBarProgress { get; set; }
-	}
+        /// <summary>
+        /// Use Windows' task bar to display progress.
+        /// </summary>
+        /// <remarks>
+        /// This feature is available on the Windows platform.
+        /// </remarks>
+        public bool EnableTaskBarProgress {
+			get => _enableTaskBarProgress;
+			set {
+				if (value && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+					throw new NotSupportedException("Task bar progress only works on Windows");
+
+				_enableTaskBarProgress = value;
+			}
+		}
+    }
 }

--- a/src/ShellProgressBar/ProgressBarOptions.cs
+++ b/src/ShellProgressBar/ProgressBarOptions.cs
@@ -3,64 +3,66 @@ using System.Runtime.InteropServices;
 
 namespace ShellProgressBar
 {
-    /// <summary>
-    /// Control the behaviour of your progressbar
-    /// </summary>
-    public class ProgressBarOptions
-    {
-        private bool _enableTaskBarProgress;
-        public static readonly ProgressBarOptions Default = new ProgressBarOptions();
+	/// <summary>
+	/// Control the behaviour of your progressbar
+	/// </summary>
+	public class ProgressBarOptions
+	{
+		private bool _enableTaskBarProgress;
+		public static readonly ProgressBarOptions Default = new ProgressBarOptions();
 
-        /// <summary> The foreground color of the progress bar, message and time</summary>
-        public ConsoleColor ForegroundColor { get; set; } = ConsoleColor.Green;
+		/// <summary> The foreground color of the progress bar, message and time</summary>
+		public ConsoleColor ForegroundColor { get; set; } = ConsoleColor.Green;
 
-        /// <summary> The foreground color the progressbar has reached a 100 percent</summary>
-        public ConsoleColor? ForegroundColorDone { get; set; }
+		/// <summary> The foreground color the progressbar has reached a 100 percent</summary>
+		public ConsoleColor? ForegroundColorDone { get; set; }
 
-        /// <summary> The background color of the remainder of the progressbar</summary>
-        public ConsoleColor? BackgroundColor { get; set; }
+		/// <summary> The background color of the remainder of the progressbar</summary>
+		public ConsoleColor? BackgroundColor { get; set; }
 
-        /// <summary> The character to use to draw the progressbar</summary>
-        public char ProgressCharacter { get; set; } = '\u2588';
+		/// <summary> The character to use to draw the progressbar</summary>
+		public char ProgressCharacter { get; set; } = '\u2588';
 
-        /// <summary>
-        /// The character to use for the background of the progress defaults to <see cref="ProgressCharacter"/>
-        /// </summary>
-        public char? BackgroundCharacter { get; set; }
+		/// <summary>
+		/// The character to use for the background of the progress defaults to <see cref="ProgressCharacter"/>
+		/// </summary>
+		public char? BackgroundCharacter { get; set; }
 
-        /// <summary>
-        /// When true will redraw the progressbar using a timer, otherwise only update when
-        /// <see cref="ProgressBarBase.Tick"/> is called.
-        /// Defaults to true
-        ///  </summary>
-        public bool DisplayTimeInRealTime { get; set; } = true;
+		/// <summary>
+		/// When true will redraw the progressbar using a timer, otherwise only update when
+		/// <see cref="ProgressBarBase.Tick"/> is called.
+		/// Defaults to true
+		///  </summary>
+		public bool DisplayTimeInRealTime { get; set; } = true;
 
-        /// <summary>
-        /// Collapse the progressbar when done, very useful for child progressbars
-        /// Defaults to true
-        /// </summary>
-        public bool CollapseWhenFinished { get; set; } = true;
+		/// <summary>
+		/// Collapse the progressbar when done, very useful for child progressbars
+		/// Defaults to true
+		/// </summary>
+		public bool CollapseWhenFinished { get; set; } = true;
 
-        /// <summary>
-        /// By default the text and time information is displayed at the bottom and the progress bar at the top.
-        /// This setting swaps their position
-        /// </summary>
-        public bool ProgressBarOnBottom { get; set; }
+		/// <summary>
+		/// By default the text and time information is displayed at the bottom and the progress bar at the top.
+		/// This setting swaps their position
+		/// </summary>
+		public bool ProgressBarOnBottom { get; set; }
 
-        /// <summary>
-        /// Use Windows' task bar to display progress.
-        /// </summary>
-        /// <remarks>
-        /// This feature is available on the Windows platform.
-        /// </remarks>
-        public bool EnableTaskBarProgress {
+		/// <summary>
+		/// Use Windows' task bar to display progress.
+		/// </summary>
+		/// <remarks>
+		/// This feature is available on the Windows platform.
+		/// </remarks>
+		public bool EnableTaskBarProgress
+		{
 			get => _enableTaskBarProgress;
-			set {
+			set
+			{
 				if (value && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 					throw new NotSupportedException("Task bar progress only works on Windows");
 
 				_enableTaskBarProgress = value;
 			}
 		}
-    }
+	}
 }


### PR DESCRIPTION
If you attempt to use the TaskbarProgress class on non-Windows platforms, it will throw a TypeLoadException stating that "COM is not supported". This is presumably because of the use of the [ComImport] attribute in TaskbarProgress.

This modifies the EnableTaskBarProgress property to throw an exception if we try to set it to true on non-Windows platforms.

It also fixes the demo to conditionally set this property based on the runtime platform.