### PR TITLE
Change interface Tick() signature to match implementation

### DIFF
--- a/src/ShellProgressBar/IProgressBar.cs
+++ b/src/ShellProgressBar/IProgressBar.cs
@@ -6,7 +6,7 @@ namespace ShellProgressBar
 	{
 		ChildProgressBar Spawn(int maxTicks, string message, ProgressBarOptions options = null);
 
-		void Tick(string message = "");
+		void Tick(string message = null);
 
 		int MaxTicks { get; set; }
 		string Message { get; set; }


### PR DESCRIPTION
Typing a `ProgressBar` or `ChildProgressBar` as `IProgressBar` causes calls to `Tick()` to use the interface signature which is currently `void Tick(string message = "")`. This passes a default empty string value to the implementation, which erases any existing message.

tl;dr This fixes an issue where in some situations setting a message then calling `Tick()` would cause the message to disappear.

A current workaround is to call `Tick(null)`.