### PR TITLE
Added option to set an estimated duration

### DIFF
--- a/src/ShellProgressBar.Example/Examples/EstimatedDurationExample.cs
+++ b/src/ShellProgressBar.Example/Examples/EstimatedDurationExample.cs
@@ -11,10 +11,9 @@ namespace ShellProgressBar.Example.Examples
 			var options = new ProgressBarOptions
 			{
 				ProgressCharacter = '─',
-				ProgressBarOnBottom = true,
 				ShowEstimatedDuration = true
 			};
-			using (var pbar = new ProgressBar(totalTicks, "progress bar is on the bottom now", options))
+			using (var pbar = new ProgressBar(totalTicks, "you can set the estimated duration too", options))
 			{
 				pbar.EstimatedDuration = TimeSpan.FromMilliseconds(totalTicks * 500);
 
@@ -23,7 +22,11 @@ namespace ShellProgressBar.Example.Examples
 				{
 					pbar.Message = $"Start {i + 1} of {totalTicks}: {initialMessage}";
 					Thread.Sleep(500);
-					pbar.Tick(i, TimeSpan.FromMilliseconds(500 * totalTicks) + TimeSpan.FromMilliseconds(500 * i), $"End {i + 1} of {totalTicks}: {initialMessage}");
+
+					// Simulate changing estimated durations while progress increases
+					var estimatedDuration =
+						TimeSpan.FromMilliseconds(500 * totalTicks) + TimeSpan.FromMilliseconds(300 * i);
+					pbar.Tick(i, estimatedDuration, $"End {i + 1} of {totalTicks}: {initialMessage}");
 				}
 			}
 		}

--- a/src/ShellProgressBar.Example/Examples/EstimatedDurationExample.cs
+++ b/src/ShellProgressBar.Example/Examples/EstimatedDurationExample.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+
+namespace ShellProgressBar.Example.Examples
+{
+	public class EstimatedDurationExample : ExampleBase
+	{
+		protected override void Start()
+		{
+			const int totalTicks = 10;
+			var options = new ProgressBarOptions
+			{
+				ProgressCharacter = '─',
+				ProgressBarOnBottom = true,
+				ShowEstimatedDuration = true
+			};
+			using (var pbar = new ProgressBar(totalTicks, "progress bar is on the bottom now", options))
+			{
+				pbar.EstimatedDuration = TimeSpan.FromMilliseconds(totalTicks * 500);
+
+				var initialMessage = pbar.Message;
+				for (var i = 0; i < totalTicks; i++)
+				{
+					pbar.Message = $"Start {i + 1} of {totalTicks}: {initialMessage}";
+					Thread.Sleep(500);
+					pbar.Tick(i, TimeSpan.FromMilliseconds(500 * totalTicks) + TimeSpan.FromMilliseconds(500 * i), $"End {i + 1} of {totalTicks}: {initialMessage}");
+				}
+			}
+		}
+	}
+}

--- a/src/ShellProgressBar.Example/Examples/EstimatedDurationExample.cs
+++ b/src/ShellProgressBar.Example/Examples/EstimatedDurationExample.cs
@@ -26,7 +26,7 @@ namespace ShellProgressBar.Example.Examples
 					// Simulate changing estimated durations while progress increases
 					var estimatedDuration =
 						TimeSpan.FromMilliseconds(500 * totalTicks) + TimeSpan.FromMilliseconds(300 * i);
-					pbar.Tick(i, estimatedDuration, $"End {i + 1} of {totalTicks}: {initialMessage}");
+					pbar.Tick(estimatedDuration, $"End {i + 1} of {totalTicks}: {initialMessage}");
 				}
 			}
 		}

--- a/src/ShellProgressBar.Example/Program.cs
+++ b/src/ShellProgressBar.Example/Program.cs
@@ -24,6 +24,7 @@ namespace ShellProgressBar.Example
 			new NeverCompletesExample(),
 			new UpdatesMaxTicksExample(),
 			new NeverTicksExample(),
+			new EstimatedDurationExample(),
 		};
 		private static readonly IList<IProgressBarExample> Examples = new List<IProgressBarExample>
 		{

--- a/src/ShellProgressBar.Example/Program.cs
+++ b/src/ShellProgressBar.Example/Program.cs
@@ -38,6 +38,7 @@ namespace ShellProgressBar.Example
 			new IntegrationWithIProgressPercentageExample(),
 			new MessageBeforeAndAfterExample(),
 			new DeeplyNestedProgressBarTreeExample(),
+			new EstimatedDurationExample()
 		};
 
 		static void Main(string[] args)

--- a/src/ShellProgressBar/ProgressBar.cs
+++ b/src/ShellProgressBar/ProgressBar.cs
@@ -25,7 +25,9 @@ namespace ShellProgressBar
 		private readonly Task _displayProgress;
 
 		public ProgressBar(int maxTicks, string message, ConsoleColor color)
-			: this(maxTicks, message, new ProgressBarOptions {ForegroundColor = color}) { }
+			: this(maxTicks, message, new ProgressBarOptions {ForegroundColor = color})
+		{
+		}
 
 		public ProgressBar(int maxTicks, string message, ProgressBarOptions options = null)
 			: base(maxTicks, message, options)
@@ -87,7 +89,7 @@ namespace ShellProgressBar
 			}
 		}
 
-		private void EnsureMainProgressBarVisible(int extraBars = 0 )
+		private void EnsureMainProgressBarVisible(int extraBars = 0)
 		{
 			var neededPadding = Math.Min(_originalWindowHeight - 2, (1 + extraBars) * 2);
 			var difference = _originalWindowHeight - _originalCursorTop;
@@ -119,7 +121,8 @@ namespace ShellProgressBar
 		}
 
 		private static void ProgressBarBottomHalf(double percentage, DateTime startDate, DateTime? endDate,
-			string message, Indentation[] indentation, bool progressBarOnBottom, bool showEstimatedDuration, TimeSpan estimatedDuration)
+			string message, Indentation[] indentation, bool progressBarOnBottom, bool showEstimatedDuration,
+			TimeSpan estimatedDuration)
 		{
 			var depth = indentation.Length;
 			var maxCharacterWidth = Console.WindowWidth - (depth * 2) + 2;
@@ -127,8 +130,9 @@ namespace ShellProgressBar
 			var durationString = GetDurationString(duration);
 
 			if (showEstimatedDuration)
-				durationString += $" / {estimatedDuration.Hours:00}:{estimatedDuration.Minutes:00}:{estimatedDuration.Seconds:00}";
-			
+				durationString +=
+					$" / {estimatedDuration.Hours:00}:{estimatedDuration.Minutes:00}:{estimatedDuration.Seconds:00}";
+
 			var column1Width = Console.WindowWidth - durationString.Length - (depth * 2) + 2;
 			var column2Width = durationString.Length;
 
@@ -249,7 +253,8 @@ namespace ShellProgressBar
 
 			if (this.Options.ProgressBarOnBottom)
 			{
-				ProgressBarBottomHalf(mainPercentage, this._startDate, null, this.Message, indentation, this.Options.ProgressBarOnBottom, Options.ShowEstimatedDuration, EstimatedDuration);
+				ProgressBarBottomHalf(mainPercentage, this._startDate, null, this.Message, indentation,
+					this.Options.ProgressBarOnBottom, Options.ShowEstimatedDuration, EstimatedDuration);
 				Console.SetCursorPosition(0, ++cursorTop);
 				TopHalf();
 			}
@@ -257,7 +262,8 @@ namespace ShellProgressBar
 			{
 				TopHalf();
 				Console.SetCursorPosition(0, ++cursorTop);
-				ProgressBarBottomHalf(mainPercentage, this._startDate, null, this.Message, indentation, this.Options.ProgressBarOnBottom, Options.ShowEstimatedDuration, EstimatedDuration);
+				ProgressBarBottomHalf(mainPercentage, this._startDate, null, this.Message, indentation,
+					this.Options.ProgressBarOnBottom, Options.ShowEstimatedDuration, EstimatedDuration);
 			}
 
 			DrawChildren(this.Children, indentation, ref cursorTop);
@@ -302,7 +308,8 @@ namespace ShellProgressBar
 			} while (++cursorTop < (windowHeight - 1));
 		}
 
-		private static void DrawChildren(IEnumerable<ChildProgressBar> children, Indentation[] indentation, ref int cursorTop)
+		private static void DrawChildren(IEnumerable<ChildProgressBar> children, Indentation[] indentation,
+			ref int cursorTop)
 		{
 			var view = children.Where(c => !c.Collapse).Select((c, i) => new {c, i}).ToList();
 			if (!view.Any()) return;
@@ -337,7 +344,9 @@ namespace ShellProgressBar
 
 				if (child.Options.ProgressBarOnBottom)
 				{
-					ProgressBarBottomHalf(percentage, child.StartDate, child.EndTime, child.Message, childIndentation, child.Options.ProgressBarOnBottom, child.Options.ShowEstimatedDuration, child.EstimatedDuration);
+					ProgressBarBottomHalf(percentage, child.StartDate, child.EndTime, child.Message, childIndentation,
+						child.Options.ProgressBarOnBottom, child.Options.ShowEstimatedDuration,
+						child.EstimatedDuration);
 					Console.SetCursorPosition(0, ++cursorTop);
 					TopHalf();
 				}
@@ -346,7 +355,8 @@ namespace ShellProgressBar
 					TopHalf();
 					Console.SetCursorPosition(0, ++cursorTop);
 
-				DrawChildren(child.Children, childIndentation, ref cursorTop);
+					DrawChildren(child.Children, childIndentation, ref cursorTop);
+				}
 			}
 		}
 
@@ -390,7 +400,9 @@ namespace ShellProgressBar
 			{
 				foreach (var c in this.Children) c.Dispose();
 			}
-			catch { }
+			catch
+			{
+			}
 
 			try
 			{

--- a/src/ShellProgressBar/ProgressBar.cs
+++ b/src/ShellProgressBar/ProgressBar.cs
@@ -100,13 +100,16 @@ namespace ShellProgressBar
 		}
 
 		private static void ProgressBarBottomHalf(double percentage, DateTime startDate, DateTime? endDate, string message,
-			Indentation[] indentation, bool progressBarOnBottom)
+			Indentation[] indentation, bool progressBarOnBottom, bool showEstimatedDuration, TimeSpan estimatedDuration)
 		{
 			var depth = indentation.Length;
 			var maxCharacterWidth = Console.WindowWidth - (depth * 2) + 2;
 			var duration = ((endDate ?? DateTime.Now) - startDate);
 			var durationString = $"{duration.Hours:00}:{duration.Minutes:00}:{duration.Seconds:00}";
 
+			if (showEstimatedDuration)
+				durationString += $" / {estimatedDuration.Hours:00}:{estimatedDuration.Minutes:00}:{estimatedDuration.Seconds:00}";
+			
 			var column1Width = Console.WindowWidth - durationString.Length - (depth * 2) + 2;
 			var column2Width = durationString.Length;
 
@@ -208,7 +211,7 @@ namespace ShellProgressBar
 
 			if (this.Options.ProgressBarOnBottom)
 			{
-				ProgressBarBottomHalf(mainPercentage, this._startDate, null, this.Message, indentation, this.Options.ProgressBarOnBottom);
+				ProgressBarBottomHalf(mainPercentage, this._startDate, null, this.Message, indentation, this.Options.ProgressBarOnBottom, Options.ShowEstimatedDuration, EstimatedDuration);
 				Console.SetCursorPosition(0, ++cursorTop);
 				TopHalf();
 			}
@@ -216,7 +219,7 @@ namespace ShellProgressBar
 			{
 				TopHalf();
 				Console.SetCursorPosition(0, ++cursorTop);
-				ProgressBarBottomHalf(mainPercentage, this._startDate, null, this.Message, indentation, this.Options.ProgressBarOnBottom);
+				ProgressBarBottomHalf(mainPercentage, this._startDate, null, this.Message, indentation, this.Options.ProgressBarOnBottom, Options.ShowEstimatedDuration, EstimatedDuration);
 			}
 
 			if (this.Options.EnableTaskBarProgress)
@@ -280,7 +283,7 @@ namespace ShellProgressBar
 
 				if (child.Options.ProgressBarOnBottom)
 				{
-					ProgressBarBottomHalf(percentage, child.StartDate, child.EndTime, child.Message, childIndentation, child.Options.ProgressBarOnBottom);
+					ProgressBarBottomHalf(percentage, child.StartDate, child.EndTime, child.Message, childIndentation, child.Options.ProgressBarOnBottom, child.Options.ShowEstimatedDuration, child.EstimatedDuration);
 					Console.SetCursorPosition(0, ++cursorTop);
 					TopHalf();
 				}
@@ -288,7 +291,7 @@ namespace ShellProgressBar
 				{
 					TopHalf();
 					Console.SetCursorPosition(0, ++cursorTop);
-					ProgressBarBottomHalf(percentage, child.StartDate, child.EndTime, child.Message, childIndentation, child.Options.ProgressBarOnBottom);
+					ProgressBarBottomHalf(percentage, child.StartDate, child.EndTime, child.Message, childIndentation, child.Options.ProgressBarOnBottom, child.Options.ShowEstimatedDuration, child.EstimatedDuration);
 				}
 
 				DrawChildren(child.Children, childIndentation, ref cursorTop);

--- a/src/ShellProgressBar/ProgressBarBase.cs
+++ b/src/ShellProgressBar/ProgressBarBase.cs
@@ -16,6 +16,7 @@ namespace ShellProgressBar
 		private int _maxTicks;
 		private int _currentTick;
 		private string _message;
+		private TimeSpan _estimatedDuration;
 
 		protected ProgressBarBase(int maxTicks, string message, ProgressBarOptions options)
 		{
@@ -64,6 +65,17 @@ namespace ShellProgressBar
 			}
 		}
 
+
+		public TimeSpan EstimatedDuration
+		{
+			get => _estimatedDuration;
+			set
+			{
+				_estimatedDuration = value;
+				DisplayProgress();
+			}
+		}
+
 		public double Percentage
 		{
 			get
@@ -95,6 +107,14 @@ namespace ShellProgressBar
 		public void Tick(int newTickCount, string message = null)
 		{
 			Interlocked.Exchange(ref _currentTick, newTickCount);
+
+			FinishTick(message);
+		}
+
+		public void Tick(int newTickCount, TimeSpan estimatedDuration, string message = null)
+		{
+			Interlocked.Exchange(ref _currentTick, newTickCount);
+			_estimatedDuration = estimatedDuration;
 
 			FinishTick(message);
 		}

--- a/src/ShellProgressBar/ProgressBarBase.cs
+++ b/src/ShellProgressBar/ProgressBarBase.cs
@@ -103,17 +103,20 @@ namespace ShellProgressBar
 		public void Tick(string message = null)
 		{
 			Interlocked.Increment(ref _currentTick);
-
 			FinishTick(message);
 		}
 
 		public void Tick(int newTickCount, string message = null)
 		{
 			Interlocked.Exchange(ref _currentTick, newTickCount);
-
 			FinishTick(message);
 		}
 
+		public void Tick(TimeSpan estimatedDuration, string message = null)
+		{
+			Interlocked.Increment(ref _currentTick);
+			FinishTick(message);
+		}
 		public void Tick(int newTickCount, TimeSpan estimatedDuration, string message = null)
 		{
 			Interlocked.Exchange(ref _currentTick, newTickCount);

--- a/src/ShellProgressBar/ProgressBarOptions.cs
+++ b/src/ShellProgressBar/ProgressBarOptions.cs
@@ -48,6 +48,13 @@ namespace ShellProgressBar
 		public bool ProgressBarOnBottom { get; set; }
 
 		/// <summary>
+		/// Whether to show the estimated time. It can be set when
+		/// <see cref="ProgressBarBase.Tick"/> is called or the property
+		/// <see cref="ProgressBarBase.EstimatedDuration"/> is set.
+		/// </summary>
+		public bool ShowEstimatedDuration { get; set; }
+
+		/// <summary>
 		/// Use Windows' task bar to display progress.
 		/// </summary>
 		/// <remarks>


### PR DESCRIPTION
Added an option to set an estimated duration for a progress bar. In some cases you are able to calculate the estimated duration for an task (e.g. downloads or uploads). This option is deactivated by default and can be set in the `ProgressBarOptions`. The estimated duration can be set by using the new overload of the `Tick` method or by setting the `EstimatedDuration` property on the progress bar.

![](https://i.imgur.com/ju8GzTY.png)