### PR TITLE
If output is redirected, disables progress bar and allows only taskbar progress display

### DIFF
--- a/src/ShellProgressBar/ProgressBar.cs
+++ b/src/ShellProgressBar/ProgressBar.cs
@@ -34,7 +34,8 @@ namespace ShellProgressBar
 			_originalWindowTop = Console.WindowTop;
 			_originalColor = Console.ForegroundColor;
 
-			Console.CursorVisible = false;
+			if (!Console.IsOutputRedirected)
+				Console.CursorVisible = false;
 
 			if (this.Options.EnableTaskBarProgress)
 				TaskbarProgress.SetState(TaskbarProgress.TaskbarStates.Normal);
@@ -188,9 +189,17 @@ namespace ShellProgressBar
 
 		private void UpdateProgress()
 		{
-			Console.CursorVisible = false;
-			var indentation = new[] {new Indentation(this.ForeGroundColor, true)};
 			var mainPercentage = this.Percentage;
+
+			if (this.Options.EnableTaskBarProgress)
+				TaskbarProgress.SetValue(mainPercentage, 100);
+
+			if (Console.IsOutputRedirected)
+				return;
+
+			Console.CursorVisible = false;
+
+			var indentation = new[] { new Indentation(this.ForeGroundColor, true) };
 			var cursorTop = _originalCursorTop;
 
 			Console.ForegroundColor = this.ForeGroundColor;
@@ -219,8 +228,6 @@ namespace ShellProgressBar
 				ProgressBarBottomHalf(mainPercentage, this._startDate, null, this.Message, indentation, this.Options.ProgressBarOnBottom);
 			}
 
-			if (this.Options.EnableTaskBarProgress)
-				TaskbarProgress.SetValue(mainPercentage, 100);
 
 			DrawChildren(this.Children, indentation, ref cursorTop);
 


### PR DESCRIPTION
Under windows, If you try to redirect output using the > an error is thrown. This is probably the reason #35 occurs also.

```
c:\test.exe > out.txt

Unhandled Exception: System.IO.IOException: The handle is invalid.

   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.Console.set_CursorVisible(Boolean value)
   at ShellProgressBar.ProgressBar..ctor(Int32 maxTicks, String message, ProgressBarOptions options)
```

So with this fix, if output is found to be redirected, the progress bar is disabled and only progress on the taskbar is shown.