### PR TITLE
Feature/master/make room for progressbar

### DIFF
--- a/src/ShellProgressBar.Example/Examples/ExampleBase.cs
+++ b/src/ShellProgressBar.Example/Examples/ExampleBase.cs
@@ -13,10 +13,10 @@ namespace ShellProgressBar.Example.Examples
 			var initialMessage = pbar.Message;
 			for (var i = 0; i < ticks && !RequestToQuit; i++)
 			{
-				pbar.Message = $"Start {i + 1} of {ticks}: {initialMessage}";
+				pbar.Message = $"Start {i + 1} of {ticks} {Console.CursorTop}/{Console.WindowHeight}: {initialMessage}";
 				childAction?.Invoke();
 				Thread.Sleep(sleep);
-				pbar.Tick($"End {i + 1} of {ticks}: {initialMessage}");
+				pbar.Tick($"End {i + 1} of {ticks} {Console.CursorTop}/{Console.WindowHeight}: {initialMessage}");
 			}
 		}
 

--- a/src/ShellProgressBar.Example/Examples/MessageBeforeAndAfterExample.cs
+++ b/src/ShellProgressBar.Example/Examples/MessageBeforeAndAfterExample.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace ShellProgressBar.Example.Examples
+{
+	public class MessageBeforeAndAfterExample : ExampleBase
+	{
+		protected override void Start()
+		{
+			Console.WriteLine("This should not be overwritten");
+			const int totalTicks = 10;
+			var options = new ProgressBarOptions
+			{
+				ForegroundColor = ConsoleColor.Yellow,
+				ForegroundColorDone = ConsoleColor.DarkGreen,
+				BackgroundColor = ConsoleColor.DarkGray,
+				BackgroundCharacter = '\u2593'
+			};
+			using (var pbar = new ProgressBar(totalTicks, "showing off styling", options))
+			{
+				TickToCompletion(pbar, totalTicks, sleep: 500);
+			}
+
+			Console.WriteLine("This should not be overwritten either afterwards");
+		}
+	}
+}

--- a/src/ShellProgressBar.Example/Program.cs
+++ b/src/ShellProgressBar.Example/Program.cs
@@ -35,6 +35,8 @@ namespace ShellProgressBar.Example
 			new ChildrenNoCollapseExample(),
 			new IntegrationWithIProgressExample(),
 			new IntegrationWithIProgressPercentageExample(),
+			new MessageBeforeAndAfterExample(),
+			new DeeplyNestedProgressBarTreeExample(),
 		};
 
 		static void Main(string[] args)
@@ -76,18 +78,8 @@ namespace ShellProgressBar.Example
 				Console.Error.WriteLine($"There are only {Examples.Count} examples, {nth} is not valid");
 			}
 			var example = Examples[nth];
-			var requestToQuit = false;
-			token.Register(() => requestToQuit = true);
 
-
-			while (!requestToQuit)
-			{
-				Console.WriteLine();
-				await example.Start(token);
-				var c = Console.Read();
-				if (c == 'q') break;
-				Console.Clear();
-			}
+			await example.Start(token);
 		}
 
 		private static async Task RunTestCases(CancellationToken token)

--- a/src/ShellProgressBar/ChildProgressBar.cs
+++ b/src/ShellProgressBar/ChildProgressBar.cs
@@ -27,6 +27,8 @@ namespace ShellProgressBar
 		private bool _calledDone;
 		private readonly object _callOnce = new object();
 
+		protected override void Grow(ProgressBarHeight direction) => _growth?.Invoke(direction);
+
 		protected override void OnDone()
 		{
 			if (_calledDone) return;

--- a/src/ShellProgressBar/ChildProgressBar.cs
+++ b/src/ShellProgressBar/ChildProgressBar.cs
@@ -39,7 +39,7 @@ namespace ShellProgressBar
 				if (this.EndTime == null)
 					this.EndTime = DateTime.Now;
 
-				if (this.Collapse)
+				if (this.Options.CollapseWhenFinished)
 					_growth?.Invoke(ProgressBarHeight.Decrement);
 
 				_calledDone = true;
@@ -50,8 +50,8 @@ namespace ShellProgressBar
 
 		public void Dispose()
 		{
-			OnDone();
 			foreach (var c in this.Children) c.Dispose();
+			OnDone();
 		}
 
 		public IProgress<T> AsProgress<T>(Func<T, string> message = null, Func<T, double?> percentage = null)

--- a/src/ShellProgressBar/ProgressBar.cs
+++ b/src/ShellProgressBar/ProgressBar.cs
@@ -271,7 +271,7 @@ namespace ShellProgressBar
 			return 1;
 		}
 
-		private static void ResetToBottom(ref int cursorTop)
+		private void ResetToBottom(ref int cursorTop)
 		{
 			var resetString = new string(' ', Console.WindowWidth);
 			var windowHeight = _originalWindowHeight + 1;

--- a/src/ShellProgressBar/ProgressBar.cs
+++ b/src/ShellProgressBar/ProgressBar.cs
@@ -15,6 +15,7 @@ namespace ShellProgressBar
 		private readonly ConsoleColor _originalColor;
 		private readonly int _originalCursorTop;
 		private readonly int _originalWindowTop;
+		private readonly int _originalWindowHeight;
 		private int _isDisposed;
 
 		private Timer _timer;
@@ -32,6 +33,7 @@ namespace ShellProgressBar
 		{
 			_originalCursorTop = Console.CursorTop;
 			_originalWindowTop = Console.WindowTop;
+			_originalWindowHeight = Console.WindowHeight + _originalWindowTop;
 			_originalColor = Console.ForegroundColor;
 
 			Console.CursorVisible = false;
@@ -237,7 +239,7 @@ namespace ShellProgressBar
 		private static void ResetToBottom(ref int cursorTop)
 		{
 			var resetString = new string(' ', Console.WindowWidth);
-			var windowHeight = Console.WindowHeight;
+			var windowHeight = _originalWindowHeight + 1;
 			if (cursorTop >= (windowHeight - 1)) return;
 			do
 			{

--- a/src/ShellProgressBar/ProgressBar.cs
+++ b/src/ShellProgressBar/ProgressBar.cs
@@ -222,7 +222,7 @@ namespace ShellProgressBar
 			if (this.Options.EnableTaskBarProgress)
 				TaskbarProgress.SetValue(mainPercentage, 100);
 
-			DrawChildren(this.Children, indentation, ref cursorTop);
+			DrawChildren(this.Children, indentation, ref cursorTop, this.Options.ScrollChildrenIntoView);
 
 			ResetToBottom(ref cursorTop);
 
@@ -245,7 +245,7 @@ namespace ShellProgressBar
 			} while (++cursorTop < (windowHeight - 1));
 		}
 
-		private static void DrawChildren(IEnumerable<ChildProgressBar> children, Indentation[] indentation, ref int cursorTop)
+		private static void DrawChildren(IEnumerable<ChildProgressBar> children, Indentation[] indentation, ref int cursorTop, bool scrollChildrenIntoView)
 		{
 			var view = children.Where(c => !c.Collapse).Select((c, i) => new {c, i}).ToList();
 			if (!view.Any()) return;
@@ -254,9 +254,12 @@ namespace ShellProgressBar
 			var lastChild = view.Max(t => t.i);
 			foreach (var tuple in view)
 			{
-				//Dont bother drawing children that would fall off the screen
-				if (cursorTop >= (windowHeight - 2))
-					return;
+				if (!scrollChildrenIntoView)
+				{
+					//Dont bother drawing children that would fall off the screen
+					if (cursorTop >= (windowHeight - 2))
+						return;
+				}
 
 				var child = tuple.c;
 				var currentIndentation = new Indentation(child.ForeGroundColor, tuple.i == lastChild);
@@ -291,7 +294,7 @@ namespace ShellProgressBar
 					ProgressBarBottomHalf(percentage, child.StartDate, child.EndTime, child.Message, childIndentation, child.Options.ProgressBarOnBottom);
 				}
 
-				DrawChildren(child.Children, childIndentation, ref cursorTop);
+				DrawChildren(child.Children, childIndentation, ref cursorTop, tuple.c.Options.ScrollChildrenIntoView);
 			}
 		}
 

--- a/src/ShellProgressBar/ProgressBar.cs
+++ b/src/ShellProgressBar/ProgressBar.cs
@@ -25,9 +25,7 @@ namespace ShellProgressBar
 		private readonly Task _displayProgress;
 
 		public ProgressBar(int maxTicks, string message, ConsoleColor color)
-			: this(maxTicks, message, new ProgressBarOptions {ForegroundColor = color})
-		{
-		}
+			: this(maxTicks, message, new ProgressBarOptions {ForegroundColor = color}) { }
 
 		public ProgressBar(int maxTicks, string message, ProgressBarOptions options = null)
 			: base(maxTicks, message, options)
@@ -87,6 +85,11 @@ namespace ShellProgressBar
 					Interlocked.Decrement(ref _visibleDescendants);
 					break;
 			}
+		}
+		public override string Message
+		{
+			get => $"{_visibleDescendants}: {base.Message}";
+			set => base.Message = value;
 		}
 
 		private void EnsureMainProgressBarVisible(int extraBars = 0 )
@@ -386,7 +389,8 @@ namespace ShellProgressBar
 			while (_stickyMessages.TryDequeue(out var m))
 				WriteConsoleLine(m);
 
-			if (this.EndTime == null) this.EndTime = DateTime.Now;
+			if (this.EndTime == null)
+				this.EndTime = DateTime.Now;
 
 			if (this.Options.EnableTaskBarProgress)
 				TaskbarProgress.SetState(TaskbarProgress.TaskbarStates.NoProgress);
@@ -399,26 +403,12 @@ namespace ShellProgressBar
 
 			try
 			{
-
 				var openDescendantsPadding = (_visibleDescendants * 2);
-				var newCursorTop = Math.Min(_originalWindowHeight, _originalCursorTop + 2 + (_visibleDescendants * 2));
+				var newCursorTop = Math.Min(_originalWindowHeight, _originalCursorTop + 2 + openDescendantsPadding);
 				Console.CursorVisible = true;
-				Console.WriteLine($"{Console.CursorTop} {newCursorTop} {_visibleDescendants}");
 				Console.SetCursorPosition(0, newCursorTop);
-
-				// var moveDown = 0;
-				// var currentWindowTop = Console.WindowTop;
-				// if (currentWindowTop != _originalWindowTop)
-				// {
-				// 	var x = Math.Max(0, Math.Min(2, currentWindowTop - _originalWindowTop));
-				// 	moveDown = _originalCursorTop + x;
-				// }
-				// else moveDown = _originalCursorTop + 2;
-				//
-				// Console.CursorVisible = true;
-				// Console.SetCursorPosition(0, openDescendantsPadding + moveDown);
 			}
-			//This is bad and I should feel bad, but i rather eat pbar exceptions in productions then causing false negatives
+			//This is bad and I should feel bad, but i rather eat pbar exceptions in production then causing false negatives
 			catch
 			{
 			}

--- a/src/ShellProgressBar/ProgressBarBase.cs
+++ b/src/ShellProgressBar/ProgressBarBase.cs
@@ -29,13 +29,9 @@ namespace ShellProgressBar
 
 		protected abstract void DisplayProgress();
 
-		protected virtual void Grow(ProgressBarHeight direction)
-		{
-		}
+		protected virtual void Grow(ProgressBarHeight direction) { }
 
-		protected virtual void OnDone()
-		{
-		}
+		protected virtual void OnDone() { }
 
 		public DateTime? EndTime { get; protected set; }
 
@@ -79,7 +75,7 @@ namespace ShellProgressBar
 
 		public ChildProgressBar Spawn(int maxTicks, string message, ProgressBarOptions options = null)
 		{
-			var pbar = new ChildProgressBar(maxTicks, message, DisplayProgress, WriteLine, options, this.Grow);
+			var pbar = new ChildProgressBar(maxTicks, message, DisplayProgress, WriteLine, options, d => this.Grow(d));
 			this.Children.Add(pbar);
 			DisplayProgress();
 			return pbar;

--- a/src/ShellProgressBar/ProgressBarBase.cs
+++ b/src/ShellProgressBar/ProgressBarBase.cs
@@ -50,9 +50,9 @@ namespace ShellProgressBar
 			}
 		}
 
-		public string Message
+		public virtual string Message
 		{
-			get => _message;
+			get => $"{_message}";
 			set
 			{
 				Interlocked.Exchange(ref _message, value);
@@ -75,7 +75,11 @@ namespace ShellProgressBar
 
 		public ChildProgressBar Spawn(int maxTicks, string message, ProgressBarOptions options = null)
 		{
-			var pbar = new ChildProgressBar(maxTicks, message, DisplayProgress, WriteLine, options, d => this.Grow(d));
+			// if this bar collapses all child progressbar will collapse
+			if (options?.CollapseWhenFinished == false && this.Options.CollapseWhenFinished)
+				options.CollapseWhenFinished = true;
+
+			var pbar = new ChildProgressBar(maxTicks, message, DisplayProgress, WriteLine, options ?? this.Options, d => this.Grow(d));
 			this.Children.Add(pbar);
 			DisplayProgress();
 			return pbar;

--- a/src/ShellProgressBar/ProgressBarOptions.cs
+++ b/src/ShellProgressBar/ProgressBarOptions.cs
@@ -39,7 +39,7 @@ namespace ShellProgressBar
 		/// Collapse the progressbar when done, very useful for child progressbars
 		/// Defaults to true
 		/// </summary>
-		public bool CollapseWhenFinished { get; set; } = true;
+		public bool CollapseWhenFinished { get; set; } = false;
 
 		/// <summary>
 		/// By default the text and time information is displayed at the bottom and the progress bar at the top.
@@ -64,12 +64,6 @@ namespace ShellProgressBar
 				_enableTaskBarProgress = value;
 			}
 		}
-
-		/// <summary>
-		/// By default child progress bars are not shown if they fall off the screen
-		/// Use this setting to make sure the next layer is scrolled into view
-		/// </summary>
-		public bool ScrollChildrenIntoView {get; set; } = false;
 
 		/// <summary>
         /// Take ownership of writing a message that is intended to be displayed above the progressbar.

--- a/src/ShellProgressBar/ProgressBarOptions.cs
+++ b/src/ShellProgressBar/ProgressBarOptions.cs
@@ -64,5 +64,11 @@ namespace ShellProgressBar
 				_enableTaskBarProgress = value;
 			}
 		}
+
+		/// <summary>
+		/// By default child progress bars are not shown if they fall off the screen
+		/// Use this setting to make sure the next layer is scrolled into view
+		/// </summary>
+		public bool ScrollChildrenIntoView {get; set; } = false;
 	}
 }

--- a/src/ShellProgressBar/ProgressBarOptions.cs
+++ b/src/ShellProgressBar/ProgressBarOptions.cs
@@ -71,7 +71,8 @@ namespace ShellProgressBar
 		/// </summary>
 		public bool ScrollChildrenIntoView {get; set; } = false;
 
-    /// Take ownership of writing a message that is intended to be displayed above the progressbar.
+		/// <summary>
+        /// Take ownership of writing a message that is intended to be displayed above the progressbar.
 		/// The delegate is expected to return the number of messages written to the console as a result of the string argument.
 		/// <para>Usescase: pretty print or change the console colors, the progressbar will reset back</para>
 		/// </summary>


### PR DESCRIPTION

![scroll-pbar](https://user-images.githubusercontent.com/245275/75097677-d89b9700-55ad-11ea-9fe0-81c61ea51b76.gif)

This is a continuation of #41 which will prevent items being drawn if they're off screen (now the default).

The progress bar will now always makes room for the progressbar and its children (with a maximum of the window height - 1).

Previously if you started a progressbar while the cursor (readline) of the shell was at the bottom the progressbar would not always be visible, only showing its top half.