### PR TITLE
Provide SPDX license identifier for packages

### DIFF
--- a/src/ShellProgressBar/ShellProgressBar.csproj
+++ b/src/ShellProgressBar/ShellProgressBar.csproj
@@ -10,6 +10,7 @@
     <Title>Cross platform simple and complex progressbars on the command line!</Title>
     <Authors>Martijn Laarman</Authors>
     <PackageLicenseUrl>http://mpdreamz.mit-license.org/</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Mpdreamz/shellprogressbar</PackageProjectUrl>
     <PackageIconUrl>https://raw.github.com/Mpdreamz/shellprogressbar/master/src/nuget-icon.png</PackageIconUrl>
     <PackageTags>console;shell;terminal;progress;progressbar</PackageTags>


### PR DESCRIPTION
This change adds the SPDX license identifier to the generated NuGet packages by adding the appropriate [PackageLicenseExpression](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/nuget) tag.

**Why?** Companies use the license information provided by package managers to ensure compliance across large projects. Providing an SPDX license identifier makes it simpler for people to work with automated tools like [LicenseFinder](https://github.com/pivotal/LicenseFinder) or GitLab's license scanning feature.