### PR TITLE
Add .NET Framework 4.6.1 target

### DIFF
--- a/src/ShellProgressBar/ShellProgressBar.csproj
+++ b/src/ShellProgressBar/ShellProgressBar.csproj
@@ -16,6 +16,10 @@
     <PackageTags>console;shell;terminal;progress;progressbar</PackageTags>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.0.1" />
   </ItemGroup>

--- a/src/ShellProgressBar/ShellProgressBar.csproj
+++ b/src/ShellProgressBar/ShellProgressBar.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>ShellProgressBar</AssemblyName>
     <RootNamespace>ShellProgressBar</RootNamespace>
-    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>ShellProgressBar</PackageId>
@@ -16,6 +16,7 @@
     <PackageTags>console;shell;terminal;progress;progressbar</PackageTags>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi guys!

I suggest adding .NET Framework 4.6.1 as a target.

In some applications made exclusively on the .NET Framework (e.g. desktop), it ends up having many unnecessary dependencies due to the .NET Standard.
As the Shell Progress Bar is fully compatible with both frameworks, I think it is worth compiling for .NET Framework 4.6.1 too.

Ah, and please let me know what the package version should be so that I can update the branch.

Thanks!
[]'s

### .NET Framework desktop app - .NET Standard target
![image](https://user-images.githubusercontent.com/7072721/98539498-302c8080-226b-11eb-8211-1e05662759c4.png)

### .NET Framework desktop app - .NET Framework target
![image](https://user-images.githubusercontent.com/7072721/98540985-7edb1a00-226d-11eb-99e5-a362a9dda64e.png)
