### PR TITLE
Fixed children not drawing other children

### DIFF
--- a/src/ShellProgressBar/ProgressBar.cs
+++ b/src/ShellProgressBar/ProgressBar.cs
@@ -365,9 +365,9 @@ namespace ShellProgressBar
 					ProgressBarBottomHalf(percentage, child.StartDate, child.EndTime, child.Message, childIndentation,
 						child.Options.ProgressBarOnBottom, child.Options.ShowEstimatedDuration,
 						child.EstimatedDuration);
-
-					DrawChildren(child.Children, childIndentation, ref cursorTop);
 				}
+
+				DrawChildren(child.Children, childIndentation, ref cursorTop);
 			}
 		}
 


### PR DESCRIPTION
This pull request is in response to issue #71 

In `ProgressBar.cs` the `DrawChildren()` function was called only if `ProgressBarOnBottom` was set to false.

```c#
if (child.Options.ProgressBarOnBottom)
    {
     ProgressBarBottomHalf(percentage, child.StartDate, child.EndTime, child.Message, childIndentation,
      child.Options.ProgressBarOnBottom, child.Options.ShowEstimatedDuration,
      child.EstimatedDuration);
     Console.SetCursorPosition(0, ++cursorTop);
     TopHalf();
    }
else
    {
     TopHalf();
     Console.SetCursorPosition(0, ++cursorTop);
     ProgressBarBottomHalf(percentage, child.StartDate, child.EndTime, child.Message, childIndentation,
      child.Options.ProgressBarOnBottom, child.Options.ShowEstimatedDuration,
      child.EstimatedDuration);

     DrawChildren(child.Children, childIndentation, ref cursorTop);
    }
```

This made children unable to draw children
![VsDebugConsole_2020-12-24_02-43-32](https://user-images.githubusercontent.com/62239520/103047386-05d12100-4594-11eb-9861-2abf8c16518a.png)


I moved the `DrawChildren()` call after the `if()`. This fixed the issue.
![VsDebugConsole_2020-12-24_02-43-20](https://user-images.githubusercontent.com/62239520/103047437-30bb7500-4594-11eb-96bc-0b27e6937651.png)



