### PR TITLE
Condensed (single line) progressbar support

### DIFF
--- a/src/ShellProgressBar.Example/Examples/PersistMessageExample.cs
+++ b/src/ShellProgressBar.Example/Examples/PersistMessageExample.cs
@@ -16,28 +16,29 @@ namespace ShellProgressBar.Example.Examples
 				WriteQueuedMessage = o =>
 				{
 					var writer = o.Error ? Console.Error : Console.Out;
+					var c = o.Error ? ConsoleColor.DarkRed : ConsoleColor.Blue;
 					if (o.Line.StartsWith("Report 500"))
 					{
-						Console.ForegroundColor = ConsoleColor.DarkRed;
+						Console.ForegroundColor = ConsoleColor.Yellow;
 						writer.WriteLine("Add an extra message, because why not");
 
-						Console.ForegroundColor = ConsoleColor.Blue;
+						Console.ForegroundColor = c;
                         writer.WriteLine(o.Line);
                         return 2; //signal to the progressbar we wrote two messages
 					}
-					Console.ForegroundColor = ConsoleColor.Blue;
+					Console.ForegroundColor = c;
 					writer.WriteLine(o.Line);
 					return 1;
 				}
 			};
-			var wait = TimeSpan.FromSeconds(5);
+			var wait = TimeSpan.FromSeconds(6);
 			using (var pbar = new FixedDurationBar(wait, "", options))
 			{
 				var t = new Thread(()=> LongRunningTask(pbar));
 				t.Start();
 
-				if (!pbar.CompletedHandle.WaitOne(wait))
-					Console.Error.WriteLine($"{nameof(FixedDurationBar)} did not signal {nameof(FixedDurationBar.CompletedHandle)} after {wait}");
+				if (!pbar.CompletedHandle.WaitOne(wait.Subtract(TimeSpan.FromSeconds(.5))))
+					pbar.WriteErrorLine($"{nameof(FixedDurationBar)} did not signal {nameof(FixedDurationBar.CompletedHandle)} after {wait}");
 
 			}
 		}

--- a/src/ShellProgressBar.Example/Program.cs
+++ b/src/ShellProgressBar.Example/Program.cs
@@ -12,7 +12,6 @@ namespace ShellProgressBar.Example
 	{
 		private static readonly IList<IProgressBarExample> TestCases = new List<IProgressBarExample>
 		{
-			new IndeterminateProgressExample(),
 			new PersistMessageExample(),
 			new FixedDurationExample(),
 			new DeeplyNestedProgressBarTreeExample(),
@@ -27,6 +26,7 @@ namespace ShellProgressBar.Example
 			new UpdatesMaxTicksExample(),
 			new NeverTicksExample(),
 			new EstimatedDurationExample(),
+			new IndeterminateProgressExample(),
 		};
 
 		private static readonly IList<IProgressBarExample> Examples = new List<IProgressBarExample>
@@ -96,7 +96,6 @@ namespace ShellProgressBar.Example
 				await example.Start(token);
 				i++;
 			}
-
 			Console.Write("Shown all examples!");
 		}
 

--- a/src/ShellProgressBar.Example/TestCases/DeeplyNestedProgressBarTreeExample.cs
+++ b/src/ShellProgressBar.Example/TestCases/DeeplyNestedProgressBarTreeExample.cs
@@ -15,6 +15,8 @@ namespace ShellProgressBar.Example.TestCases
 
 			var overProgressOptions = new ProgressBarOptions
 			{
+				DenseProgressBar = true,
+				ProgressCharacter = '─',
 				BackgroundColor = ConsoleColor.DarkGray,
 				EnableTaskBarProgress = RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
 			};
@@ -23,6 +25,7 @@ namespace ShellProgressBar.Example.TestCases
 			{
 				var stepBarOptions = new ProgressBarOptions
 				{
+					DenseProgressBar = true,
 					ForegroundColor = ConsoleColor.Cyan,
 					ForegroundColorDone = ConsoleColor.DarkGreen,
 					ProgressCharacter = '─',
@@ -33,6 +36,7 @@ namespace ShellProgressBar.Example.TestCases
 				{
 					var workBarOptions = new ProgressBarOptions
 					{
+						DenseProgressBar = true,
 						ForegroundColor = ConsoleColor.Yellow,
 						ProgressCharacter = '─',
 						BackgroundColor = ConsoleColor.DarkGray,

--- a/src/ShellProgressBar.sln
+++ b/src/ShellProgressBar.sln
@@ -19,6 +19,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShellProgressBar.Tests", "..\test\ShellProgressBar.Tests\ShellProgressBar.Tests.csproj", "{7F6B9B22-0375-46C4-ADEB-30F5BF6DB7B2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{25EEC6B1-4113-41F4-8181-674E4855F40A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{25EEC6B1-4113-41F4-8181-674E4855F40A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{25EEC6B1-4113-41F4-8181-674E4855F40A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F6B9B22-0375-46C4-ADEB-30F5BF6DB7B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F6B9B22-0375-46C4-ADEB-30F5BF6DB7B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F6B9B22-0375-46C4-ADEB-30F5BF6DB7B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F6B9B22-0375-46C4-ADEB-30F5BF6DB7B2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ShellProgressBar/FixedDurationBar.cs
+++ b/src/ShellProgressBar/FixedDurationBar.cs
@@ -12,7 +12,8 @@ namespace ShellProgressBar
 
 		public FixedDurationBar(TimeSpan duration, string message, ConsoleColor color) : this(duration, message, new ProgressBarOptions {ForegroundColor = color}) { }
 
-		public FixedDurationBar(TimeSpan duration,  string message, ProgressBarOptions options = null) : base((int)Math.Ceiling(duration.TotalSeconds), message, options)
+		public FixedDurationBar(TimeSpan duration,  string message, ProgressBarOptions options = null)
+			: base((int)Math.Ceiling(duration.TotalSeconds) * 2, message, options)
 		{
 			if (!this.Options.DisplayTimeInRealTime)
 				throw new ArgumentException(
@@ -24,7 +25,7 @@ namespace ShellProgressBar
 		protected override void OnTimerTick()
 		{
 			Interlocked.Increment(ref _seenTicks);
-			if (_seenTicks % 2 == 0) this.Tick();
+			this.Tick();
 			base.OnTimerTick();
 		}
 

--- a/src/ShellProgressBar/ProgressBar.cs
+++ b/src/ShellProgressBar/ProgressBar.cs
@@ -143,17 +143,15 @@ namespace ShellProgressBar
 		{
 			var depth = indentation.Length;
 			var messageWidth = 30;
-			var width = (Console.WindowWidth - (depth * 2) + 2) - messageWidth;
+			var maxCharacterWidth = Console.WindowWidth - (depth * 2) + 2;
+			var truncatedMessage = StringExtensions.Excerpt(message, messageWidth - 2) + " ";
+			var width = (Console.WindowWidth - (depth * 2) + 2) - truncatedMessage.Length;
 
-			var truncatedMessage = StringExtensions.Excerpt(message, messageWidth - 2);
-			//if (progressBarOnTop)
-			//else
-			//DrawTopHalfPrefix(indentation, depth);
 
 			var newWidth = (int) ((width * percentage) / 100d);
 			var progBar = new string(progressCharacter, newWidth);
 			DrawBottomHalfPrefix(indentation, depth);
-			Console.Write(truncatedMessage + " ");
+			Console.Write(truncatedMessage);
 			Console.Write(progBar);
 			if (backgroundColor.HasValue)
 			{

--- a/src/ShellProgressBar/ProgressBarOptions.cs
+++ b/src/ShellProgressBar/ProgressBarOptions.cs
@@ -48,6 +48,11 @@ namespace ShellProgressBar
 		public bool ProgressBarOnBottom { get; set; }
 
 		/// <summary>
+		/// Progressbar is written on a single line
+		/// </summary>
+		public bool DenseProgressBar { get; set; }
+
+		/// <summary>
 		/// Whether to show the estimated time. It can be set when
 		/// <see cref="ProgressBarBase.Tick"/> is called or the property
 		/// <see cref="ProgressBarBase.EstimatedDuration"/> is set.

--- a/test/ShellProgressBar.Tests/ShellProgressBar.Tests.csproj
+++ b/test/ShellProgressBar.Tests/ShellProgressBar.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net5.0</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+
+        <LangVersion>latest</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="1.3.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\ShellProgressBar\ShellProgressBar.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/ShellProgressBar.Tests/UnitTest1.cs
+++ b/test/ShellProgressBar.Tests/UnitTest1.cs
@@ -1,0 +1,16 @@
+using System;
+using Xunit;
+
+namespace ShellProgressBar.Tests
+{
+	public class UnitTest1
+	{
+		[Fact]
+		public void Test1()
+		{
+			using var pbar = new ProgressBar(1000, "task");
+			pbar.Tick();
+			pbar.WriteLine("Asdad");
+		}
+	}
+}


### PR DESCRIPTION


https://user-images.githubusercontent.com/245275/106298356-15f3b480-6254-11eb-895e-231b02e0503b.mp4

Scrollbars were always atleast 2 lines in height. 

This PR allows you to configure scrollbar and each of its children to be displayed on a single line

