### PR TITLE
Remove references to System.Text.Encoding.CodePages

### DIFF
--- a/src/ShellProgressBar.Example/Program.cs
+++ b/src/ShellProgressBar.Example/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using ShellProgressBar.Example.Examples;
@@ -46,7 +45,6 @@ namespace ShellProgressBar.Example
 
 		static void Main(string[] args)
 		{
-			Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 			var cts = new CancellationTokenSource();
 			Console.CancelKeyPress += (s, e) =>
 			{

--- a/src/ShellProgressBar/ProgressBarBase.cs
+++ b/src/ShellProgressBar/ProgressBarBase.cs
@@ -1,17 +1,11 @@
 using System;
 using System.Collections.Concurrent;
-using System.Text;
 using System.Threading;
 
 namespace ShellProgressBar
 {
 	public abstract class ProgressBarBase
 	{
-		static ProgressBarBase()
-		{
-			Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-		}
-
 		protected readonly DateTime _startDate = DateTime.Now;
 		private int _maxTicks;
 		private int _currentTick;

--- a/src/ShellProgressBar/ShellProgressBar.csproj
+++ b/src/ShellProgressBar/ShellProgressBar.csproj
@@ -21,6 +21,5 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This was introduced in d0481de8141016a03c7d58403633cedc01cf907f (port for .NET Core) but is actually not required for ShellProgressBar to work.