### PR TITLE
Fix #94, #89 Estimated duration "overflow" if > 24h, Tick doesn't update estimatedDuration

### DIFF
--- a/src/ShellProgressBar/ProgressBar.cs
+++ b/src/ShellProgressBar/ProgressBar.cs
@@ -179,7 +179,7 @@ namespace ShellProgressBar
 
 			if (showEstimatedDuration)
 				durationString +=
-					$" / {estimatedDuration.Hours:00}:{estimatedDuration.Minutes:00}:{estimatedDuration.Seconds:00}";
+					$" / {GetDurationString(estimatedDuration)}";
 
 			var column1Width = Console.WindowWidth - durationString.Length - (depth * 2) + 2;
 			var column2Width = durationString.Length;

--- a/src/ShellProgressBar/ProgressBarBase.cs
+++ b/src/ShellProgressBar/ProgressBarBase.cs
@@ -127,6 +127,8 @@ namespace ShellProgressBar
 		public void Tick(TimeSpan estimatedDuration, string message = null)
 		{
 			Interlocked.Increment(ref _currentTick);
+			_estimatedDuration = estimatedDuration;
+
 			FinishTick(message);
 		}
 		public void Tick(int newTickCount, TimeSpan estimatedDuration, string message = null)


### PR DESCRIPTION
Fix #94 , Fix #89 