### PR TITLE
Adds option to configure the Foreground Done Color

### DIFF
--- a/src/ShellProgressBar.Example/Examples/AlternateFinishedColorExample.cs
+++ b/src/ShellProgressBar.Example/Examples/AlternateFinishedColorExample.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ShellProgressBar.Example.Examples
+{
+	public class AlternateFinishedColorExample : ExampleBase
+	{
+		protected override void Start()
+		{
+			var options = new ProgressBarOptions
+			{
+				ForegroundColor = ConsoleColor.Yellow,
+				ForegroundColorDone = ConsoleColor.DarkGreen,
+				BackgroundColor = ConsoleColor.DarkGray,
+				BackgroundCharacter = '\u2593'
+			};
+
+			using (var pbar = new IndeterminateProgressBar("Indeterminate", options))
+			{
+				Task.Run(
+					() =>
+					{
+						for (var i = 0; i < 100; i++)
+						{
+							pbar.Message= $"The progress is beating to its own drum (indeterminate) {i}";
+							Task.Delay(10).Wait();
+						}
+					}).Wait();
+				pbar.Finished();
+				pbar.ForegroundColorDone = ConsoleColor.Red;
+				pbar.Message= "Indicate the task is done, but the status is not Green.";
+			}
+
+			Task.Delay(5000).Wait();
+		}
+
+
+	}
+}

--- a/src/ShellProgressBar.Example/Examples/AlternateFinishedColorExample.cs
+++ b/src/ShellProgressBar.Example/Examples/AlternateFinishedColorExample.cs
@@ -12,23 +12,24 @@ namespace ShellProgressBar.Example.Examples
 			{
 				ForegroundColor = ConsoleColor.Yellow,
 				ForegroundColorDone = ConsoleColor.DarkGreen,
+				ForegroundColorError = ConsoleColor.Red,
 				BackgroundColor = ConsoleColor.DarkGray,
 				BackgroundCharacter = '\u2593'
 			};
 
-			using (var pbar = new IndeterminateProgressBar("Indeterminate", options))
+			using (var pbar = new ProgressBar(100, "100 ticks", options))
 			{
 				Task.Run(
 					() =>
 					{
-						for (var i = 0; i < 100; i++)
+						for (var i = 0; i < 10; i++)
 						{
-							pbar.Message= $"The progress is beating to its own drum (indeterminate) {i}";
 							Task.Delay(10).Wait();
+							pbar.Tick($"Step {i}");
 						}
+						pbar.WriteErrorLine("The task ran into an issue!");
+						// OR pbar.ObservedError = true;
 					}).Wait();
-				pbar.Finished();
-				pbar.ForegroundColorDone = ConsoleColor.Red;
 				pbar.Message= "Indicate the task is done, but the status is not Green.";
 			}
 

--- a/src/ShellProgressBar.Example/Program.cs
+++ b/src/ShellProgressBar.Example/Program.cs
@@ -27,6 +27,7 @@ namespace ShellProgressBar.Example
 			new NeverTicksExample(),
 			new EstimatedDurationExample(),
 			new IndeterminateProgressExample(),
+			new AlternateFinishedColorExample()
 		};
 
 		private static readonly IList<IProgressBarExample> Examples = new List<IProgressBarExample>
@@ -41,7 +42,8 @@ namespace ShellProgressBar.Example
 			new MessageBeforeAndAfterExample(),
 			new DeeplyNestedProgressBarTreeExample(),
 			new EstimatedDurationExample(),
-			new DownloadProgressExample()
+			new DownloadProgressExample(),
+			new AlternateFinishedColorExample()
 		};
 
 		static void Main(string[] args)

--- a/src/ShellProgressBar.Example/Program.cs
+++ b/src/ShellProgressBar.Example/Program.cs
@@ -12,6 +12,7 @@ namespace ShellProgressBar.Example
 	{
 		private static readonly IList<IProgressBarExample> TestCases = new List<IProgressBarExample>
 		{
+			/*
 			new PersistMessageExample(),
 			new FixedDurationExample(),
 			new DeeplyNestedProgressBarTreeExample(),
@@ -28,6 +29,7 @@ namespace ShellProgressBar.Example
 			new EstimatedDurationExample(),
 			new IndeterminateProgressExample(),
 			new IndeterminateChildrenNoCollapseExample(),
+			*/
 			new AlternateFinishedColorExample()
 		};
 

--- a/src/ShellProgressBar/ProgressBar.cs
+++ b/src/ShellProgressBar/ProgressBar.cs
@@ -277,6 +277,7 @@ namespace ShellProgressBar
 		}
 		public override void WriteErrorLine(string message)
 		{
+			this.ObservedError = true;
 			_stickyMessages.Enqueue(new ConsoleOutLine(message, error: true));
 			DisplayProgress();
 		}

--- a/src/ShellProgressBar/ProgressBarBase.cs
+++ b/src/ShellProgressBar/ProgressBarBase.cs
@@ -36,15 +36,7 @@ namespace ShellProgressBar
 
 		public DateTime? EndTime { get; protected set; }
 
-		private ConsoleColor? _dynamicForegroundColorDone = null;
-		public ConsoleColor? ForegroundColorDone
-		{
-			get
-			{
-				return _dynamicForegroundColorDone ?? this.Options.ForegroundColorDone;
-			}
-			set => _dynamicForegroundColorDone = value;
-		}
+		public bool ObservedError { get; set; }
 
 		private ConsoleColor? _dynamicForegroundColor = null;
 		public ConsoleColor ForegroundColor
@@ -52,8 +44,11 @@ namespace ShellProgressBar
 			get
 			{
 				var realColor = _dynamicForegroundColor ?? this.Options.ForegroundColor;
+				if (this.ObservedError && this.Options.ForegroundColorError.HasValue)
+					return this.Options.ForegroundColorError.Value;
+
 				return EndTime.HasValue
-					? ForegroundColorDone ?? realColor
+					? this.Options.ForegroundColorDone ?? realColor
 					: realColor;
 			}
 			set => _dynamicForegroundColor = value;

--- a/src/ShellProgressBar/ProgressBarBase.cs
+++ b/src/ShellProgressBar/ProgressBarBase.cs
@@ -36,6 +36,16 @@ namespace ShellProgressBar
 
 		public DateTime? EndTime { get; protected set; }
 
+		private ConsoleColor? _dynamicForegroundColorDone = null;
+		public ConsoleColor? ForegroundColorDone
+		{
+			get
+			{
+				return _dynamicForegroundColorDone ?? this.Options.ForegroundColorDone;
+			}
+			set => _dynamicForegroundColor = value;
+		}
+		
 		private ConsoleColor? _dynamicForegroundColor = null;
 		public ConsoleColor ForegroundColor
 		{
@@ -43,7 +53,7 @@ namespace ShellProgressBar
 			{
 				var realColor = _dynamicForegroundColor ?? this.Options.ForegroundColor;
 				return EndTime.HasValue
-					? this.Options.ForegroundColorDone ?? realColor
+					? ForegroundColorDone ?? realColor
 					: realColor;
 			}
 			set => _dynamicForegroundColor = value;

--- a/src/ShellProgressBar/ProgressBarBase.cs
+++ b/src/ShellProgressBar/ProgressBarBase.cs
@@ -43,9 +43,9 @@ namespace ShellProgressBar
 			{
 				return _dynamicForegroundColorDone ?? this.Options.ForegroundColorDone;
 			}
-			set => _dynamicForegroundColor = value;
+			set => _dynamicForegroundColorDone = value;
 		}
-		
+
 		private ConsoleColor? _dynamicForegroundColor = null;
 		public ConsoleColor ForegroundColor
 		{

--- a/src/ShellProgressBar/ProgressBarOptions.cs
+++ b/src/ShellProgressBar/ProgressBarOptions.cs
@@ -31,6 +31,14 @@ namespace ShellProgressBar
 		/// <summary> The foreground color the progressbar has reached a 100 percent</summary>
 		public ConsoleColor? ForegroundColorDone { get; set; }
 
+		/// <summary>
+		/// The foreground color the progressbar when it has observed an error
+		/// <para>If set this takes priority over any other color as soon as an error is observed</para>
+		/// Use either <see cref="ProgressBarBase.ObservedError"/> or <see cref="ProgressBarBase.WriteErrorLine"/> to
+		/// put the progressbar in errored state
+		/// </summary>
+		public ConsoleColor? ForegroundColorError { get; set; }
+
 		/// <summary> The background color of the remainder of the progressbar</summary>
 		public ConsoleColor? BackgroundColor { get; set; }
 

--- a/src/ShellProgressBar/ShellProgressBar.csproj
+++ b/src/ShellProgressBar/ShellProgressBar.csproj
@@ -16,7 +16,7 @@
     <PackageTags>console;shell;terminal;progress;progressbar</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Adds an option to configure the Foreground Done Color in the same Style as the configurable Foreground color.
Adds an example for its usage.

Motivation:
Sometimes a task may fail, but the Done color must be configured ahead of time. The color of the progress bar may then mislead the user into thinking the process was successful when it was not.