### PR TITLE
Option to add child as indeterminate progress bar

### DIFF
--- a/src/ShellProgressBar.Example/Examples/IndeterminateChildrenNoCollapse.cs
+++ b/src/ShellProgressBar.Example/Examples/IndeterminateChildrenNoCollapse.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading;
+
+namespace ShellProgressBar.Example.Examples
+{
+	public class IndeterminateChildrenNoCollapseExample : ExampleBase
+	{
+		protected override void Start()
+		{
+			const int totalChildren = 10;
+			Random random = new Random();
+			var options = new ProgressBarOptions
+			{
+				ForegroundColor = ConsoleColor.Yellow,
+				BackgroundColor = ConsoleColor.DarkGray,
+				ProgressCharacter = '─'
+			};
+			var childOptions = new ProgressBarOptions
+			{
+				ForegroundColor = ConsoleColor.Green,
+				BackgroundColor = ConsoleColor.DarkGray,
+				ProgressCharacter = '─',
+				CollapseWhenFinished = false
+			};
+			using (var pbar = new ProgressBar(totalChildren, "main progressbar", options))
+			{
+				for (int i = 1; i <= totalChildren; i++)
+				{
+					pbar.Message = $"Start {i} of {totalChildren}: main progressbar";
+					using (var child = pbar.SpawnIndeterminate("child action " + i, childOptions))
+					{
+						Thread.Sleep(1000 * random.Next(5, 15));
+						child.Finished();
+					}
+					pbar.Tick();
+				}
+			}
+		}
+	}
+}

--- a/src/ShellProgressBar.Example/Program.cs
+++ b/src/ShellProgressBar.Example/Program.cs
@@ -27,6 +27,7 @@ namespace ShellProgressBar.Example
 			new NeverTicksExample(),
 			new EstimatedDurationExample(),
 			new IndeterminateProgressExample(),
+			new IndeterminateChildrenNoCollapseExample(),
 		};
 
 		private static readonly IList<IProgressBarExample> Examples = new List<IProgressBarExample>

--- a/src/ShellProgressBar/IndeterminateChildProgressBar.cs
+++ b/src/ShellProgressBar/IndeterminateChildProgressBar.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace ShellProgressBar
+{
+	public class IndeterminateChildProgressBar : ChildProgressBar
+	{
+		private const int MaxTicksForIndeterminate = 20;
+		private Timer _timer;
+		internal IndeterminateChildProgressBar(
+			string message,
+			Action scheduleDraw,
+			Action<string> writeLine,
+			Action<string> writeError,
+			ProgressBarOptions options = null,
+			Action<ProgressBarHeight> growth = null
+		)
+			: base(MaxTicksForIndeterminate, message, scheduleDraw, writeLine, writeError, options, growth)
+		{
+			if (options == null)
+			{
+				options = new ProgressBarOptions();
+			}
+
+			options.DisableBottomPercentage = true;
+			_timer = new Timer((s) => OnTimerTick(), null, 500, 500);
+		}
+
+		private long _seenTicks = 0;
+
+		protected void OnTimerTick()
+		{
+			Interlocked.Increment(ref _seenTicks);
+			if (_seenTicks == MaxTicksForIndeterminate - 1)
+			{
+				this.Tick(0);
+				Interlocked.Exchange(ref _seenTicks, 0);
+			}
+			else
+			{
+				this.Tick();
+			}
+			DisplayProgress();
+		}
+
+		public void Finished()
+		{
+			_timer.Change(Timeout.Infinite, Timeout.Infinite);
+			_timer.Dispose();
+			Tick(MaxTicksForIndeterminate);
+		}
+
+		public void Dispose()
+		{
+			foreach (var c in this.Children) c.Dispose();
+			OnDone();
+		}
+	}
+}

--- a/src/ShellProgressBar/IndeterminateChildProgressBar.cs
+++ b/src/ShellProgressBar/IndeterminateChildProgressBar.cs
@@ -53,6 +53,7 @@ namespace ShellProgressBar
 
 		public void Dispose()
 		{
+			if (_timer != null) _timer.Dispose();
 			foreach (var c in this.Children) c.Dispose();
 			OnDone();
 		}

--- a/src/ShellProgressBar/ProgressBarBase.cs
+++ b/src/ShellProgressBar/ProgressBarBase.cs
@@ -108,6 +108,20 @@ namespace ShellProgressBar
 			return pbar;
 		}
 
+		public IndeterminateChildProgressBar SpawnIndeterminate(string message, ProgressBarOptions options = null)
+		{
+			// if this bar collapses all child progressbar will collapse
+			if (options?.CollapseWhenFinished == false && this.Options.CollapseWhenFinished)
+				options.CollapseWhenFinished = true;
+
+			var pbar = new IndeterminateChildProgressBar(
+				message, DisplayProgress, WriteLine, WriteErrorLine, options ?? this.Options, d => this.Grow(d)
+			);
+			this.Children.Add(pbar);
+			DisplayProgress();
+			return pbar;
+		}
+
 		public abstract void WriteLine(string message);
 		public abstract void WriteErrorLine(string message);
 


### PR DESCRIPTION
Right now, the only option as child progress bars are regular ones with known max ticks.

This PR adds the option to create child progress bars with unknown duration. The behavior of this progress child is similar to the main `IndeterminateProgressBar`.

There is also a working example.