### PR TITLE
Fix Percentage property floating point issues

### DIFF
--- a/src/ShellProgressBar/ProgressBarBase.cs
+++ b/src/ShellProgressBar/ProgressBarBase.cs
@@ -90,7 +90,7 @@ namespace ShellProgressBar
 		{
 			get
 			{
-				var percentage = Math.Max(0, Math.Min(100, (100.0 / this._maxTicks) * this._currentTick));
+				var percentage = Math.Max(0, Math.Min(100, 100.0 * this._currentTick / this._maxTicks));
 				// Gracefully handle if the percentage is NaN due to division by 0
 				if (double.IsNaN(percentage) || percentage < 0) percentage = 100;
 				return percentage;


### PR DESCRIPTION
Hello!

Sometimes, depending on the values of `MaxTicks` and `CurrentTick`, progress bars fails to complete due to floating point arithmetic issues.

Here is a screenshot from my debugger where the `Percentage` property should be 100, but is slightly off. This PR aims to fix that.
![image](https://github.com/Mpdreamz/shellprogressbar/assets/66096725/68f2b2d3-3520-4f77-896c-2a7579430a01)

Code to reproduce:
```cs
const int max = 369;

ProgressBar progress = new ProgressBar(max, "test", new ProgressBarOptions
{
    ProgressBarOnBottom = true,
    BackgroundColor = ConsoleColor.DarkGray
});

for (int i = 0; i < max; i++)
{
    progress.Tick();
    Thread.Sleep(1);
}

Console.WriteLine($"Progress bar Percentage: {progress.Percentage}");
Console.WriteLine($"Progress bar CurrentTick and MaxTicks: {progress.CurrentTick} / {progress.MaxTicks}");
```

Tested with ShellProgressBar `5.2.0` and .NET `8.0.200`.